### PR TITLE
Improve teleport boundaries

### DIFF
--- a/src/witchazzan/core.clj
+++ b/src/witchazzan/core.clj
@@ -148,8 +148,8 @@
        (let [tele (filter
                    #(and
                      (= "SwitchToScene" (get % "type"))
-                     (within-n (:x coords) (get % "x") (* 2 (get % "width")))
-                     (within-n (:y coords) (get % "y") (* 2 (get % "height"))))
+                     (within-n (:x coords) (+ 8 (get % "x")) (get % "width"))
+                     (within-n (:y coords) (+ 8 (get % "y")) (get % "height")))
                    objects)]
          (when (= 1 (count tele))
            (let [result (first (filter #(and


### PR DESCRIPTION
I think the code is fundamentally flawed, or at the very least, I cannot
comprehend what it is doing, but it is produces a more sane set of
teleport boundaris now.

I still do not understand why they:
1. Do not extend the full width/height like the objects.
2. The bottom one extends off of the scene.
3. The right one cannot fill the scene.