### PR TITLE
Use the actual spell name as the sprite, so that the client can use a

### DIFF
--- a/src/witchazzan/behavior.clj
+++ b/src/witchazzan/behavior.clj
@@ -263,7 +263,7 @@
                                     :y (:y this)
                                     :spell spell
                                     :scene (:scene this)
-                                    :sprite "fireball"
+                                    :sprite spell
                                     :speed 0.01
                                     :direction (:direction this)
                                     :milliseconds (System/currentTimeMillis)


### PR DESCRIPTION
different sprite for each spell.

Or a flaming goose, that may also happen.