### PR TITLE
Add Access-Control-Allow-Credentials header to 401 responses

### DIFF
--- a/src/witchazzan/world.clj
+++ b/src/witchazzan/world.clj
@@ -130,15 +130,17 @@
   (fn [request]
     (if (:auth (:session request))
       (handler request)
-      (-> (response "Access Denied")
-          (status 401)))))
+      (-> (response "Access Denied" )
+          (status 401)
+          (header "Access-Control-Allow-Credentials" "true")))))
 
 (defn admin? [handler]
   (fn [request]
     (if (:admin (:session request))
       (handler request)
       (-> (response "Access Denied")
-          (status 401)))))
+          (status 401)
+          (header "Access-Control-Allow-Credentials" "true")))))
 
 (compojure/defroutes all-routes
   (wrap-session


### PR DESCRIPTION
Adding this to each response one at a time probably isn't the best
solution, but it lets me continue working on the client login code.