### PR TITLE
Add Access-Control-Allow-Credentials header to auth response

### DIFF
--- a/src/witchazzan/world.clj
+++ b/src/witchazzan/world.clj
@@ -107,6 +107,7 @@
         user (jdbc/execute-one! ds ["select * from users where username= ?" name])]
     (if (and user (password/check password (:users/password user)))
       (-> (response "<a href='/api'> Auth succesful</a>")
+          (header "Access-Control-Allow-Credentials" "true")
           (assoc :session (assoc session :auth (:users/id user) :admin (:users/admin user))))
       "try again")))
 


### PR DESCRIPTION
Adding this to each response one at a time probably isn't the best
solution, but it lets me continue working on the client login code.